### PR TITLE
Review: 1761-not-possible-to-view-import-list-or-clear-previous-errors

### DIFF
--- a/app/CsvImporter/Entities/Activity/Components/ActivityRow.php
+++ b/app/CsvImporter/Entities/Activity/Components/ActivityRow.php
@@ -265,7 +265,7 @@ class ActivityRow extends Row
     {
         $activityIdentifier = (string) Arr::get($this->data(), 'identifier.activity_identifier');
 
-        if (ImportCacheHelper::activityAlreadyBeingImported($this->organizationId, $activityIdentifier)) {
+        if (ImportCacheHelper::isThisActivityBeingImported($this->organizationId, $activityIdentifier)) {
             return;
         }
 

--- a/app/IATI/Services/ImportActivity/ImportXlsService.php
+++ b/app/IATI/Services/ImportActivity/ImportXlsService.php
@@ -230,6 +230,10 @@ class ImportXlsService
                 if ($oldActivity['has_ever_been_published']) {
                     $activityData['iati_identifier']['iati_identifier_text'] = $oldActivity['iati_identifier']['iati_identifier_text'];
                     $activityData['iati_identifier']['present_organization_identifier'] = $oldActivity['iati_identifier']['present_organization_identifier'];
+                } else {
+                    $organizationIdentifier = Auth::user()->organization->identifier;
+                    $activityData['iati_identifier']['iati_identifier_text'] = $organizationIdentifier . '-' . Arr::get($activityData, 'iati_identifier.activity_identifier');
+                    $activityData['iati_identifier']['present_organization_identifier'] = $organizationIdentifier;
                 }
 
                 $this->activityRepository->update($existingId, $activityData);

--- a/app/XlsImporter/Foundation/Mapper/Activity.php
+++ b/app/XlsImporter/Foundation/Mapper/Activity.php
@@ -286,6 +286,7 @@ class Activity
      * Validates mapped data and store them to json files.
      *
      * @return void
+     * @throws \JsonException
      */
     public function validateAndStoreData(): void
     {
@@ -314,7 +315,7 @@ class Activity
                 $this->errorCount['critical'] += count(Arr::get($this->processingErrors, $activityIdentifier));
             }
 
-            if (!ImportCacheHelper::activityAlreadyBeingImported($orgId, $activityIdentifier)) {
+            if (!ImportCacheHelper::isThisActivityBeingImported($orgId, $activityIdentifier)) {
                 $this->storeValidatedData($activity, $error, $existingId, $activityIdentifier);
             }
 

--- a/app/XmlImporter/Foundation/XmlQueueWriter.php
+++ b/app/XmlImporter/Foundation/XmlQueueWriter.php
@@ -146,7 +146,7 @@ class XmlQueueWriter
     {
         $activityIdentifier = Arr::get($mappedActivity, 'iati_identifier.activity_identifier');
 
-        if (ImportCacheHelper::activityAlreadyBeingImported($this->orgId, $activityIdentifier)) {
+        if (ImportCacheHelper::isThisActivityBeingImported($this->orgId, $activityIdentifier)) {
             return false;
         }
 

--- a/resources/assets/js/views/import/XlsList.vue
+++ b/resources/assets/js/views/import/XlsList.vue
@@ -461,6 +461,10 @@ const addActivities = () => {
       .post(`/import/xls/activity`, { activities: selectedActivities.value })
       .then(() => {
         window.location.href = '/activities';
+      })
+      .catch((error) => {
+        console.error(error);
+        window.location.href = '/activities';
       });
   }
 };

--- a/resources/assets/sass/component/_input.scss
+++ b/resources/assets/sass/component/_input.scss
@@ -252,41 +252,41 @@ label {
 }
 
 select.select2.default-value-indicator
-+ .select2
-.selection
-.select2-selection:not(:focus) {
+  + .select2
+  .selection
+  .select2-selection:not(:focus) {
   border: 2px solid #3f9a7c;
   background-color: #3f9a7c15;
 }
 
 select.select2.default-value-indicator
-+ .select2
-.selection
-.select2-selection:not(:focus) {
+  + .select2
+  .selection
+  .select2-selection:not(:focus) {
   border: 2px solid #3f9a7c;
   background-color: #3f9a7c15;
 }
 
 select.select2.default-value-indicator
-+ .select2
-.selection
-.select2-selection
-.select2-selection__placeholder {
+  + .select2
+  .selection
+  .select2-selection
+  .select2-selection__placeholder {
   color: var(--bluecoral-50);
 }
 
 select.select2.default-value-indicator
-+ .select2.select2-container--open
-.selection
-.select2-selection {
+  + .select2.select2-container--open
+  .selection
+  .select2-selection {
   border: 1px solid #a6b5ba;
   background-color: white;
 }
 
 select.select2.default-value-indicator
-+ .select2
-.selection
-.select2-selection.select2-selection--clearable {
+  + .select2
+  .selection
+  .select2-selection.select2-selection--clearable {
   border: 1px solid #a6b5ba;
   background-color: white;
 }


### PR DESCRIPTION
- [x] Fixed activity identifier missing iati_identifier_text causing "Import Activity" to crash
- [x] Fix import status not being cleared even on exception causing users to be able to view listing page even after crash
- [x] Fixed cache comparison instead of assignment